### PR TITLE
chore: add eslint-plugin-import to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^9.37.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-github": "^6.0.0",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.0.1",
         "eslint-plugin-prettier": "^5.0.1",
         "globals": "^16.4.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-github": "^6.0.0",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-prettier": "^5.0.1",
     "globals": "^16.4.0",


### PR DESCRIPTION
This pull request makes a minor update to the project's development dependencies by adding the `eslint-plugin-import` package to `package.json`. This plugin helps enforce best practices when importing modules in JavaScript and TypeScript projects.