### PR TITLE
chore: update minimum npm package version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,15 +53,15 @@
   },
   "devDependencies": {
     "@joshjohanning/make-coverage-badge-better": "^1.0.1",
-    "@vercel/ncc": "^0.38.1",
+    "@vercel/ncc": "^0.38.4",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-github": "^6.0.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.0.1",
-    "eslint-plugin-prettier": "^5.0.1",
+    "eslint-plugin-prettier": "^5.5.4",
     "globals": "^16.5.0",
     "jest": "^30.2.0",
-    "prettier": "^3.0.0"
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
Not updating the npm versions since they were already up to date in package-lock.json but updating the minimum spec.