### PR TITLE
chore: set create_release_as_draft to support immutable releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,4 @@ jobs:
           commit_node_modules: false
           publish_minor_version: false
           publish_release_branch: false
+          create_release_as_draft: true


### PR DESCRIPTION
- Set the `create_release_as_draft` option to `true` in the `.github/workflows/publish.yml` workflow file, so releases are created as drafts.