### PR TITLE
ci: update npm-version-check-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
           fi
 
       - name: Check npm version compatibility
-        uses: joshjohanning/npm-version-check-action@v1
+        uses: joshjohanning/npm-version-check-action@v2


### PR DESCRIPTION
## Summary

Update CI dependency reference since the action has been upgraded to node24.

- `npm-version-check-action`: `@v1` → `@v2` (self-reference in CI workflow)