### PR TITLE
fix: use notice instead of warning annotation when no relevant files changed

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -3426,7 +3426,7 @@ describe('npm Version Check Action - Integration Tests', () => {
       // Should log that all commits were skipped
       expect(mockCore.notice).toHaveBeenCalledWith('⏭️  Skipped 2 of 2 commits containing "[skip version]"');
       // When all files are skipped, changedFiles is empty so no relevant changes detected
-      expect(mockCore.warning).toHaveBeenCalledWith(
+      expect(mockCore.notice).toHaveBeenCalledWith(
         '⏭️  No JavaScript/TypeScript files or dependency changes detected, skipping version check'
       );
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1193,7 +1193,7 @@ export async function run() {
         } else {
           logMessage(
             '⏭️  No JavaScript/TypeScript files or dependency changes detected, skipping version check',
-            'warning'
+            'notice'
           );
         }
         return;


### PR DESCRIPTION
## Summary

Changes the "no relevant files changed" skip message from a `warning` to `notice` annotation, consistent with the dev-dependency skip message change in #72.

## Why

Skipping the version check when no relevant files changed is expected behavior, not something requiring attention. A yellow warning annotation was misleading.