### PR TITLE
docs(readme): add permissions and improve usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ jobs:
 ```
 
 > **Note:** The `pull-requests: read` permission is required because the action
-> uses the GitHub Pulls API to retrieve commit messages for `[skip version]`
-> keyword support.
+> uses the GitHub Pulls API to retrieve commits from the pull request for
+> per-commit file analysis and `[skip version]` keyword support.
 
 ### Advanced Configuration
 


### PR DESCRIPTION
Add required permissions (contents: read, pull-requests: read) to usage examples and document the pull-requests: read requirement for the Pulls API used in [skip version] keyword support. Expand the advanced configuration snippet into a complete job definition.