### PR TITLE
docs: add immutable releases badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # npm-version-check-action
 
 [![GitHub release](https://img.shields.io/github/release/joshjohanning/npm-version-check-action.svg?labelColor=333)](https://github.com/joshjohanning/npm-version-check-action/releases)
+[![Immutable releases](https://img.shields.io/badge/releases-immutable-blue?labelColor=333)](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
 [![GitHub marketplace](https://img.shields.io/badge/marketplace-npm--version--check--action-blue?logo=github)](https://github.com/marketplace/actions/npm-version-check-action)
 [![CI](https://github.com/joshjohanning/npm-version-check-action/actions/workflows/ci.yml/badge.svg)](https://github.com/joshjohanning/npm-version-check-action/actions/workflows/ci.yml)
 [![Publish GitHub Action](https://github.com/joshjohanning/npm-version-check-action/actions/workflows/publish.yml/badge.svg)](https://github.com/joshjohanning/npm-version-check-action/actions/workflows/publish.yml)


### PR DESCRIPTION
Add the [immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) badge to the README, consistent with the other JS actions in the suite.
